### PR TITLE
DEPRECATION: Python 2.6 is no longer supported by the Python core tea…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev"  # 3.5 development branch
   - "3.6"
-  - "3.6-dev"  # 3.6 development branch
-  - "3.7-dev"  # 3.7 development branch
-  - "nightly"
 
 # Install dependencies
 install:


### PR DESCRIPTION
…m, please upgrade your Python. A future version of pip will drop support for Python 2.6

Other dev version cannot guarentee behaivor